### PR TITLE
Support XDG environment settings

### DIFF
--- a/movielst/config.py
+++ b/movielst/config.py
@@ -1,14 +1,33 @@
+from pathlib import Path
 import configparser
 import os
 
-CONFIG_PATH = os.path.expanduser('~/.movielst/')
-CONFIG_FILE = os.path.expanduser('config.ini')
+APP_NAME = 'movielst'
+
+XDG_CACHE_HOME = Path(os.environ.get('XDG_CACHE_HOME') or '~/.cache').expanduser()
+XDG_CONFIG_HOME = Path(os.environ.get('XDG_CONFIG_HOME') or '~/.config').expanduser()
+XDG_DATA_HOME = Path(os.environ.get('XDG_DATA_HOME') or '~/.local/share').expanduser()
+
+# Support legacy locations.
+LEGACY_PATH = Path('~/.movielst').expanduser()
+if LEGACY_PATH.is_dir():
+    CACHE_DIR = CONFIG_DIR = DATA_DIR = LEGACY_PATH
+else:
+    CACHE_DIR = XDG_CACHE_HOME / APP_NAME
+    CONFIG_DIR = XDG_CONFIG_HOME / APP_NAME
+    DATA_DIR = XDG_DATA_HOME / APP_NAME
+
+CONFIG_PATH = CONFIG_DIR / 'config.ini'
 
 
 def create_config():
-    if not os.path.exists(CONFIG_PATH):
-        os.makedirs(CONFIG_PATH)
-    if not os.path.exists(CONFIG_PATH + CONFIG_FILE):
+    for path in CACHE_DIR, CONFIG_DIR, DATA_DIR:
+        try:
+            path.mkdir(parents=True)
+        except FileExistsError:
+            pass
+
+    if not CONFIG_PATH.exists():
         config = configparser.ConfigParser()
 
         config.add_section('General')
@@ -17,8 +36,8 @@ def create_config():
         config.add_section('Web')
 
         config.set('General', 'log_level', 'INFO')
-        config.set('General', 'log_location', CONFIG_PATH)
-        config.set('Index', 'location', CONFIG_PATH)
+        config.set('General', 'log_location', str(CACHE_DIR) + '/')
+        config.set('Index', 'location', str(DATA_DIR) + '/')
         config.set('Index', 'min_size_to_index', '25')
         config.set('API', 'use_external_api', 'omdb')
         config.set('API', 'OMDb_API_key', '37835d63')
@@ -27,13 +46,13 @@ def create_config():
         config.set('Web', 'port', '5000')
         config.set('Web', 'require_login', "False")
 
-        with open(CONFIG_PATH + CONFIG_FILE, 'w') as config_file:
+        with CONFIG_PATH.open('w') as config_file:
             config.write(config_file)
 
 
 def get_config():
     config = configparser.ConfigParser()
-    config.read(CONFIG_PATH + CONFIG_FILE)
+    config.read(str(CONFIG_PATH))
     return config
 
 
@@ -45,5 +64,5 @@ def get_setting(section, setting, fallback=None):
 def update_config(section, setting, value):
     config = get_config()
     config.set(section, setting, value)
-    with open(CONFIG_PATH + CONFIG_FILE, 'w') as config_file:
+    with CONFIG_PATH.open('w') as config_file:
         config.write(config_file)

--- a/movielst/movielst.py
+++ b/movielst/movielst.py
@@ -264,11 +264,11 @@ def util(args):
             logger.warning('Used something else than supported arguments for exporting.')
     elif args.edit_config:
         if platform.system() == 'Darwin':
-            subprocess.call(('open', CONFIG_PATH + CONFIG_FILE))
+            subprocess.call(('open', str(CONFIG_PATH)))
         elif platform.system() == 'Linux':
-            subprocess.call(('xdg-open', CONFIG_PATH + CONFIG_FILE))
+            subprocess.call(('xdg-open', str(CONFIG_PATH)))
         elif platform.system() == 'Windows':
-            subprocess.call(('start', CONFIG_PATH + CONFIG_FILE), shell=True)
+            subprocess.call(('start', str(CONFIG_PATH)), shell=True)
         else:
             print("Can not open the configuration file. System not supported.")
 
@@ -326,15 +326,21 @@ def util(args):
 
 
 def cache_images(urls):
-    if not os.path.exists(CONFIG_PATH + 'cache/'):
-        os.makedirs(CONFIG_PATH + 'cache/')
+    cache_dir = CACHE_DIR / 'images'
+
+    try:
+        cache_dir.mkdir(parents=True)
+    except FileExistsError:
+        pass
+
     for i in urls:
         logger.debug(i[1])
         hash_name = hashlib.sha256(uuid.uuid4().hex.encode() + i[1].encode()).hexdigest()
         logger.debug("HASH : " + str(hash_name))
         try:
-            urllib.request.urlretrieve(i[1], CONFIG_PATH + 'cache/' + str(hash_name) + '.jpg')
-            edit('poster', i[0], CONFIG_PATH + 'cache/' + str(hash_name) + '.jpg')
+            cache_path = str((cache_dir / hash_name).with_suffix('.jpg'))
+            urllib.request.urlretrieve(i[1], cache_path)
+            edit('poster', i[0], cache_path)
         except ValueError as error:
             logger.error(error)
         except urllib.error.URLError:

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(name='movielst',
           'tqdm',
           'colorama',
           'xlsxwriter',
+          'requests',
           'flask',
           'Flask-WTF',
           'passlib'

--- a/web/dependency.py
+++ b/web/dependency.py
@@ -2,7 +2,7 @@ from movielst import config
 import requests
 import os
 
-dep_folder = config.CONFIG_PATH + 'dep/'
+dep_folder = config.CACHE_DIR / 'deps'
 dependencies = ['https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css',
                 'https://code.jquery.com/jquery-3.3.1.min.js',
                 'https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js',
@@ -11,17 +11,21 @@ dependencies = ['https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstra
 
 
 def check_for_dep():
-    if not os.path.exists(dep_folder):
-        os.makedirs(dep_folder)
+    try:
+        dep_folder.mkdir(parents=True)
+    except FileExistsError:
+        pass
+
     for url in dependencies:
-        if not os.path.exists(dep_folder + url.rsplit('/', 1)[-1]):
+        local_path = dep_folder / url.rsplit('/', 1)[-1]
+        if not local_path.exists():
             download_dep(url)
 
 
 def download_dep(url):
     local_filename = url.split('/')[-1]
     r = requests.get(url, stream=True)
-    with open(dep_folder + local_filename, 'wb') as f:
+    with (dep_folder / local_filename).open('wb') as f:
         for chunk in r.iter_content(chunk_size=1024):
             if chunk:
                 f.write(chunk)

--- a/web/templates/home.html
+++ b/web/templates/home.html
@@ -17,7 +17,7 @@
                     <div class="gallery">
                         <a href="/movie/{{ movie["title"] }} ">
                             {% if cached %}
-                                <img class="b-lazy" data-src="{{ url_for('cached_image_file', filename=movie['poster'].split('cache/')[1]) }}" onerror="this.src='{{ url_for('static', filename='default-poster.png') }}';" src="{{ url_for('static', filename='default-poster.png') }}" />
+                                <img class="b-lazy" data-src="{{ url_for('cached_image_file', filename=movie['poster']) }}" onerror="this.src='{{ url_for('static', filename='default-poster.png') }}';" src="{{ url_for('static', filename='default-poster.png') }}" />
                             {% else %}
                                 <img class="b-lazy" data-src="{{ movie['poster'] }}" onerror="this.src='{{ url_for('static', filename='default-poster.png') }}';" src="{{ url_for('static', filename='default-poster.png') }}" />
                             {% endif %}


### PR DESCRIPTION
The [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) is supported by many applications and aims to help a user keep their home directory a bit more tidy.

This PR adds support for the following locations from the spec:
- all cache files are put into $XDG_CACHE_HOME
- the config file lives in $XDG_CONFIG_HOME
- the database is stored in $XDG_DATA_HOME

To support existing users the code first checks if `~/.movielst` exists and only uses the XDG dirs if `~/.movielst` does **not** exist.

Some caches will have to be rebuilt though (or manually migrated), because their locations changed:
- `~/.movielst/cache` -> `~/.movielst/cache/images`
- `~/.movielst/dep` -> `~/.movielst/cache/deps`

The locations of the `config.ini` and `movies.db` are not affected (for legacy users).